### PR TITLE
Add repository tree to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,165 @@
 # lowercaseLabs
 lowercaseLabs 
 
+## Directory Tree
+
+```text
+.
+|-- .github
+|   `-- workflows
+|-- .gitignore
+|-- AI_README.md
+|-- ClothesPicker
+|   |-- .pylintrc
+|   |-- CLOTHES_INSTRUCTION.prompt
+|   |-- CLOTHES_LIST.prompt
+|   |-- README.md
+|   |-- Test.ipynb
+|   `-- utils.py
+|-- README.md
+|-- REFACTOR_VIEWS.md
+|-- cntx
+|   |-- .gitignore
+|   |-- README.md
+|   |-- backend
+|   |-- data
+|   |-- frontend
+|   `-- package-lock.json
+|-- dump
+|   `-- Classification.ipynb
+|-- gpt_shell
+|   `-- gpt.sh
+|-- jupyterDocker
+|   |-- cpu
+|   `-- setup.sh
+|-- localOnly
+|   |-- .gitignore
+|   |-- Makefile
+|   |-- README.md
+|   |-- backend
+|   |-- docker-compose.yml
+|   |-- docs
+|   |-- ios-app
+|   |-- test-apps
+|   `-- web-harness
+|-- mail
+|   |-- .env.example
+|   |-- .gitignore
+|   |-- IMAP\ access
+|   |-- README.md
+|   |-- docker
+|   |-- docker-compose.yml
+|   |-- docs
+|   |-- packages
+|   |-- pyproject.toml
+|   |-- requirements.txt
+|   |-- services
+|   `-- uv.lock
+|-- mapper
+|   |-- .gitignore
+|   |-- Dockerfile
+|   |-- README.md
+|   |-- client
+|   |-- docker-compose.otp.yml
+|   |-- fly.toml
+|   |-- otp
+|   |-- package-lock.json
+|   |-- package.json
+|   |-- scripts
+|   `-- server
+|-- meetUp
+|   |-- README.md
+|   |-- main.py
+|   |-- pyproject.toml
+|   `-- uv.lock
+|-- metrain
+|   |-- README.md
+|   `-- imessage_exporter.py
+|-- qork
+|   |-- .gitignore
+|   |-- AGENTS.md
+|   |-- README.md
+|   |-- build.sh
+|   |-- pyproject.toml
+|   |-- qork
+|   |-- tests
+|   |-- upload.sh
+|   `-- uv.lock
+|-- raggar
+|   |-- README.md
+|   `-- chatter
+|-- research
+|   |-- SAP
+|   `-- unfiltered
+|-- sapProject
+|   |-- AAL\ dataset
+|   |-- AAVE.jsonl
+|   |-- PrelimAnalysis.ipynb
+|   `-- WAE.jsonl
+|-- theVoidLocal
+|   |-- AGENT.md
+|   |-- Makefile
+|   |-- STATE.md
+|   |-- backend
+|   |-- docker-compose.yml
+|   |-- fly.postgres.toml
+|   |-- fly.toml
+|   `-- theVoid
+|-- trasher
+|   |-- .gitignore
+|   |-- README.md
+|   |-- pyproject.toml
+|   |-- src
+|   `-- uv.lock
+|-- zagency
+|   |-- Makefile
+|   |-- NEW_FRAMEWORK.md
+|   |-- README.md
+|   |-- Thesis.md
+|   |-- etc
+|   |-- pyproject.toml
+|   |-- tests
+|   `-- zagency
+|-- zagent
+|   `-- AGENTS.md
+|-- zimer
+|   |-- README.md
+|   |-- pyproject.toml
+|   |-- tests
+|   |-- zimer
+|   `-- zimer.egg-info
+|-- znote
+|   |-- .notes_config.json
+|   |-- README.md
+|   |-- docs
+|   |-- pyproject.toml
+|   |-- src
+|   |-- test_bh
+|   |-- tests
+|   |-- text.md
+|   `-- uv.lock
+|-- zubillow
+|   |-- 500_limit_sf.json
+|   |-- README.md
+|   |-- main.py
+|   |-- manual_zillow.py
+|   |-- pyproject.toml
+|   |-- rentalcast_api.py
+|   |-- uv.lock
+|   `-- zillow-mcp-server
+`-- zudget
+    |-- .gitignore
+    |-- AGENT.md
+    |-- Dockerfile
+    |-- README.md
+    |-- backend
+    |-- data
+    |-- docker-compose.yml
+    `-- frontend
+
+65 directories, 87 files
+```
+
 ## On Update Frequency:
 
 I push code much more frequently than I push readme's. I attempt to maintain decent README into this repo by using AI_README.md --> an AI generated readme. 


### PR DESCRIPTION
## What was done
- added a `Directory Tree` section to `README.md`
- included the current tree output for the repository at the top level

## Why
- the original task was to capture this directory's tree and add that output to the README so the repo structure is easier to scan